### PR TITLE
feat: update devcontainer configuration and add AWS CloudWatch log group

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,39 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
 {
-	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {},
-		"ghcr.io/devcontainers-contrib/features/checkov:1": {},
-		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
-		"ghcr.io/devcontainers-contrib/features/terraform-docs:1": {},
-		"ghcr.io/devcontainers-contrib/features/tfsec:1": {}
-	}
-
+	"name": "devcontainer",
+	"image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04",
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/checkov:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/terraform:1": {
+			"version": "1.5.0",
+			"tflint": "0.47.0",
+			"installTFsec": "true",
+			"installTerraformDocs": "true"
+		},
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/terrascan:1": {
+			"version": "latest"
+		}
+	},
+	"shutdownAction": "stopContainer",
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
+	"postCreateCommand": {
+		"one": "tflint --init",
+		"two": "pre-commit"
+	},
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ No modules.
 |------|------|
 | [aws_cloudwatch_event_rule.fsx_health_lambda_schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.fsx_health_lambda_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.fsx_health_lambda_log_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.fsx_health_lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.fsx_health_lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.fsx_health_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -47,6 +48,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_email"></a> [email](#input\_email) | List of e-mail addresses subscribing to the SNS topic. Default is empty list. | `list(string)` | `[]` | no |
+| <a name="input_log_retion_period_in_days"></a> [log\_retion\_period\_in\_days](#input\_log\_retion\_period\_in\_days) | Number of days logs will be retained. Default is 365 days. | `number` | `365` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The schedule expression for the CloudWatch event rule. Default is 'rate(60 minutes)'. | `string` | `"rate(60 minutes)"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Default is empty map. | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,6 @@ resource "aws_iam_policy" "fsx_health_lambda_role_policy" {
     "Statement": [
         {
             "Action": [
-                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents"
             ],
@@ -55,6 +54,13 @@ resource "aws_iam_policy" "fsx_health_lambda_role_policy" {
 }
 EOF
   tags   = var.tags
+}
+
+# Log group for the Lambda function
+resource "aws_cloudwatch_log_group" "fsx_health_lambda_log_groups" {
+  name              = "/aws/lambda/fsx-health-lambda-function-${random_id.id.hex}"
+  retention_in_days = var.log_retion_period_in_days
+  tags              = var.tags
 }
 
 # IAM role

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,18 @@ variable "email" {
   default     = []
 }
 
+variable "log_retion_period_in_days" {
+  type        = number
+  default     = 365
+  description = "Number of days logs will be retained. Default is 365 days."
+
+  validation {
+    condition = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365,
+    400, 545, 731, 1096, 1827, 2192, 2557, 2992, 3288, 3653], var.log_retion_period_in_days)
+    error_message = "log_retion_period_in_days must be one of the allowed values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653"
+  }
+}
+
 variable "schedule_expression" {
   description = "The schedule expression for the CloudWatch event rule. Default is 'rate(60 minutes)'."
   type        = string


### PR DESCRIPTION
- Added a new resource for an AWS CloudWatch log group in main.tf.
- Created a new variable "log_retion_period_in_days" with a default value of 365 days in variables.tf.