### PR TITLE
feat: allow to configure Lambda function memory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.83.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_email"></a> [email](#input\_email) | List of e-mail addresses subscribing to the SNS topic. Default is empty list. | `list(string)` | `[]` | no |
 | <a name="input_log_retion_period_in_days"></a> [log\_retion\_period\_in\_days](#input\_log\_retion\_period\_in\_days) | Number of days logs will be retained. Default is 365 days. | `number` | `365` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160. | `string` | `"160"` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The schedule expression for the CloudWatch event rule. Default is 'rate(60 minutes)'. | `string` | `"rate(60 minutes)"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Default is empty map. | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ resource "aws_lambda_function" "fsx_health_lambda" {
   role                           = aws_iam_role.fsx_health_lambda_role.arn
   handler                        = "fsx-health.lambda_handler"
   runtime                        = "python3.8"
+  memory_size                    = var.memory_size
   reserved_concurrent_executions = 1
   tracing_config {
     mode = "Active"

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "log_retion_period_in_days" {
   }
 }
 
+variable "memory_size" {
+  type        = string
+  description = "Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160."
+  default     = "160"
+}
+
 variable "schedule_expression" {
   description = "The schedule expression for the CloudWatch event rule. Default is 'rate(60 minutes)'."
   type        = string


### PR DESCRIPTION
Add a new input variable called `memory_size`, which allows users to specify the amount of memory in MByte that the Lambda Function can use at runtime. The default value is set to `"160"`.