### PR TITLE
fix: update memory_size type

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,15 +25,6 @@
 		}
 	},
 	"shutdownAction": "stopContainer",
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": {
-		"one": "tflint --init",
-		"two": "pre-commit"
-	},
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
-}
+		"one": "tflint --init"
+	}}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_email"></a> [email](#input\_email) | List of e-mail addresses subscribing to the SNS topic. Default is empty list. | `list(string)` | `[]` | no |
 | <a name="input_log_retion_period_in_days"></a> [log\_retion\_period\_in\_days](#input\_log\_retion\_period\_in\_days) | Number of days logs will be retained. Default is 365 days. | `number` | `365` | no |
-| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160. | `string` | `"160"` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160. | `number` | `160` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The schedule expression for the CloudWatch event rule. Default is 'rate(60 minutes)'. | `string` | `"rate(60 minutes)"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Default is empty map. | `map(string)` | `{}` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,9 +17,13 @@ variable "log_retion_period_in_days" {
 }
 
 variable "memory_size" {
-  type        = string
+  type        = number
   description = "Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160."
-  default     = "160"
+  default     = 160
+  validation {
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240
+    error_message = "memory_size must be between 128 and 10240"
+  }
 }
 
 variable "schedule_expression" {


### PR DESCRIPTION
- Updated the default value of memory_size in README.md to be a number instead of a string
- Added validation for memory_size in variables.tf to ensure it falls between 128 and 10240
- Refactored the postCreateCommand in devcontainer.json to only include "tflint --init"