### PR TITLE
feat: add support for setting treat_missing_data in CloudWatch alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_alarms_treat_missing_data"></a> [cloudwatch\_alarms\_treat\_missing\_data](#input\_cloudwatch\_alarms\_treat\_missing\_data) | Sets how the alarms handle missing data points. The following values are supported: `missing`, `ignore`, `breaching` and `notBreaching`. Default is `breaching`. | `string` | `"breaching"` | no |
 | <a name="input_email"></a> [email](#input\_email) | List of e-mail addresses subscribing to the SNS topic. Default is empty list. | `list(string)` | `[]` | no |
 | <a name="input_enable_cloudwatch_alarms"></a> [enable\_cloudwatch\_alarms](#input\_enable\_cloudwatch\_alarms) | Setup CloudWatch alarms for the FSx filesystem state. For each state a separate alarm will be created. Default is false. | `bool` | `false` | no |
 | <a name="input_enable_sns_notifications"></a> [enable\_sns\_notifications](#input\_enable\_sns\_notifications) | Setup SNS notifications for the FSx filesystem state. Default is false. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,10 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   evaluation_periods        = 2
   statistic                 = "Average"
   threshold                 = 0
+  treat_missing_data        = var.cloudwatch_alarms_treat_missing_data
+  alarm_actions             = []
   insufficient_data_actions = []
+  ok_actions                = []
   dimensions = {
     FileSystemId = each.key
   }

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -6,3 +6,19 @@ run "eventbridge_default_schedule_expression" {
     error_message = "Schedule expression is not matching expected value of rate(5 minutes)"
   }
 }
+
+##
+# The default value for CloudWatch Alarm property treat_missing_data should be set to breaching.
+##
+run "aws_cloudwatch_metric_alarm_default_treat_missing_data" {
+  command = plan
+  variables {
+    filesystem_ids                         = ["fs-01234567890123456"]
+    enable_cloudwatch_alarms             = true
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.this["fs-01234567890123456"].treat_missing_data == "breaching"
+    error_message = "The default value for treat_missing_data is not set to breaching."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,17 @@ variable "enable_cloudwatch_alarms" {
   default     = false
 }
 
+variable "cloudwatch_alarms_treat_missing_data" {
+  description = "Sets how the alarms handle missing data points. The following values are supported: `missing`, `ignore`, `breaching` and `notBreaching`. Default is `breaching`."
+  type        = string
+  default     = "breaching"
+  validation {
+    condition     = can(regex("^(missing|ignore|breaching|notBreaching)$", var.cloudwatch_alarms_treat_missing_data))
+    error_message = "The value must be one of missing, ignore, breaching or notBreaching."
+  }
+}
+
+
 variable "enable_sns_notifications" {
   description = "Setup SNS notifications for the FSx filesystem state. Default is false."
   type        = bool


### PR DESCRIPTION
This commit adds support for setting the `treat_missing_data` property in CloudWatch alarms. The property determines how the alarms handle missing data points and supports values such as `missing`, `ignore`, `breaching`, and `notBreaching`. The default value is set to `breaching`.

Fixes #43 