### PR TITLE
ci: upgrade github actions

### DIFF
--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning

--- a/.github/workflows/tf-module-actions.yml
+++ b/.github/workflows/tf-module-actions.yml
@@ -10,18 +10,18 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Render terraform docs inside the README.md and push changes back to PR branch
-      uses: terraform-docs/gh-actions@v1.0.0
+      uses: terraform-docs/gh-actions@v1.1.0
       with:
         working-dir: .,examples/01_default_configuration,examples/02_custom_schedule
         output-file: README.md
         output-method: inject
         git-push: "true"
     - name: Run Trivy vulnerability scanner in IaC mode
-      uses: aquasecurity/trivy-action@0.13.1
+      uses: aquasecurity/trivy-action@0.19.0
       with:
         scan-type: 'config'
         hide-progress: false
@@ -31,7 +31,7 @@ jobs:
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH,MEDIUM'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-config-results.sarif'
         category: 'Trivy IaC Scan'

--- a/.github/workflows/tf-module-release.yml
+++ b/.github/workflows/tf-module-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
- Upgraded 'actions/checkout' to version 4 in multiple workflows.
- Updated 'terraform-docs/gh-actions' to v1.1.0 and 'aquasecurity/trivy-action' to v0.19.0, also updated 'github/codeql-action/upload-sarif' to v3 for improved functionality.